### PR TITLE
Can publish FBX from Maya

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -540,7 +540,14 @@ paths:
     # The location of published maya files
     maya_asset_publish:
         definition: '@asset_root/publish/maya/{name}.v{version}.{maya_extension}'
-
+   # The location of FBX exports for Unreal
+    maya_asset_fbx_publish:
+        definition: '@asset_root/publish/fbx/{name}.v{version}.fbx'
+    # The location of turntable review output rendered in Unreal
+    maya_ue4_turntable_render:
+        definition: '@asset_root/work/images/{name}_turntable_v{version}.avi'
+    maya_ue4_turntable_publish:
+        definition: '@asset_root/review/{Asset}_{name}_turntable_v{version}.avi'
 
     #
     # Houdini

--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -169,7 +169,7 @@ settings.tk-multi-publish2.mari.asset_step:
 
 # asset step
 settings.tk-multi-publish2.maya.asset_step:
-  collector: "{self}/collector.py:{engine}/tk-multi-publish2/basic/collector.py"
+  collector: "{self}/collector.py:{config}/tk-multi-publish2/tk-maya/basic/collector.py"
   collector_settings:
       Work Template: maya_asset_work
   publish_plugins:


### PR DESCRIPTION
I missed a few items the first time (used `git grep unreal`, next time: `git grep -i unreal` and `git grep -i ue4`...)
With this we can publish fbx.
When merged, move the tag `update_to_tk_config_unreal-v1.3.0` to the merge commit.